### PR TITLE
xlsxファイルのパースが空になる問題を修正

### DIFF
--- a/exparso/core/parse_core_service.py
+++ b/exparso/core/parse_core_service.py
@@ -44,6 +44,8 @@ class ParseCoreService:
             # 画像認識が必要ない場合は余計な処理を行わない
             if DocumentTypeEnum.TEXT_ONLY in document_type.types or not document_type.types:
                 logger.debug("Document Type is Text Only")
+                # テキストのみの場合でも基本的な内容は保持する
+                parsed_contents.append(PageContents.from_load_data(page))
                 continue
 
             input_parse_document = InputParseDocument(


### PR DESCRIPTION
## 関連Issue
Fixes #3

## 概要
  LLMモデルが指定された際に、テキストベースファイル（xlsx、csv、txt）の内容が空になってしまう問題を修正

## 問題の詳細
- xlsxファイルをparse_document関数で処理する際、LLMモデルが指定されている場合に`Contents length: 0`となってしまう
- ParseCoreServiceにてTEXT_ONLYタイプのファイルが完全にスキップされることが原因

## 修正内容
- `exparso/core/parse_core_service.py`の47-48行目を修正
- TEXT_ONLYタイプの場合でも、`PageContents.from_load_data(page)`で基本的な内容を保持
- LLM解析は不要なのでスキップするが、テキスト内容は適切に保存

## テスト結果
- [x] 問題のあったxlsxファイルでの手動テストで正常な内容取得を確認
- [x] 既存の単体テストが全て成功（回帰なし）

## 影響範囲
- xlsx、csv、txtなどのテキストベースファイル全般
- 画像ファイルやPDFなどには影響なし